### PR TITLE
Add CI job to validate installation of wxWidgets

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/validate-win.yml
+++ b/.github/workflows/validate-win.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
-        win-version: ["windows-2019", "windows-2022"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        win-version: ["windows-2019", "windows-2022", "windows-latest"]
 
     steps:
       - uses: actions/checkout@v3
@@ -37,3 +37,9 @@ jobs:
       - name: Run script
         run: |
           python setup.py
+      - name: Output PATH
+        run: |
+          echo $PATH
+      - name: Run Minimal wxWidgets sample
+        run: |
+          msbuild C:\wxWidgets-3.2.1\samples\minimal\minimal.vcxproj

--- a/.github/workflows/validate-win.yml
+++ b/.github/workflows/validate-win.yml
@@ -46,7 +46,7 @@ jobs:
           $folderWildCard = "wxWidgets-*"
           $folder = Get-ChildItem -Path "C:\" -Filter $folderWildCard -Directory | Select-Object -First 1
           $folderPath = $folder.FullName  # Get the full path of the selected folder
-          msbuild "$folderPath\samples\minimal\minimal_vc17.sln"
+          msbuild "$folderPath\samples\minimal\minimal_vc16.sln"
       - name: Run Minimal wxWidgets sample (VS 2022)
         if: matrix.win-version == 'windows-2022' || matrix.win-version == 'windows-latest'
         run: |

--- a/.github/workflows/validate-win.yml
+++ b/.github/workflows/validate-win.yml
@@ -45,16 +45,18 @@ jobs:
         run: |
           $folderWildCard = "wxWidgets-*"
           $folder = Get-ChildItem -Path "C:\" -Filter $folderWildCard -Directory | Select-Object -First 1
-          msbuild C:\$folder\samples\minimal\minimal_vc16.sln
+          $folderPath = $folder.FullName  # Get the full path of the selected folder
+          msbuild "$folderPath\samples\minimal\minimal_vc17.sln"
       - name: Run Minimal wxWidgets sample (VS 2022)
         if: matrix.win-version == 'windows-2022' || matrix.win-version == 'windows-latest'
         run: |
           $folderWildCard = "wxWidgets-*"
           $folder = Get-ChildItem -Path "C:\" -Filter $folderWildCard -Directory | Select-Object -First 1
-          msbuild C:\$folder\samples\minimal\minimal_vc17.sln
+          $folderPath = $folder.FullName  # Get the full path of the selected folder
+          msbuild "$folderPath\samples\minimal\minimal_vc17.sln"
       - name: Find built binary
         run: |
           $folderWildCard = "wxWidgets-*"
           $folder = Get-ChildItem -Path "C:\" -Filter $folderWildCard -Directory | Select-Object -First 1
-          $binary = Get-ChildItem -Path "C:\$folder\samples\minimal\vc_mswud\*.exe" | Select-Object -First 1
+          $binary = Get-ChildItem -Path "$folder\samples\minimal\vc_mswud\*.exe" | Select-Object -First 1
           echo $binary

--- a/.github/workflows/validate-win.yml
+++ b/.github/workflows/validate-win.yml
@@ -40,6 +40,21 @@ jobs:
       - name: Output PATH
         run: |
           echo $PATH
-      - name: Run Minimal wxWidgets sample
+      - name: Run Minimal wxWidgets sample (VS 2019)
+        if: matrix.win-version == 'windows-2019'
         run: |
-          msbuild C:\wxWidgets-3.2.1\samples\minimal\minimal.vcxproj
+          $folderWildCard = "wxWidgets-*"
+          $folder = Get-ChildItem -Path "C:\" -Filter $folderWildCard -Directory | Select-Object -First 1
+          msbuild C:\$folder\samples\minimal\minimal_vc16.sln
+      - name: Run Minimal wxWidgets sample (VS 2022)
+        if: matrix.win-version == 'windows-2022' || matrix.win-version == 'windows-latest'
+        run: |
+          $folderWildCard = "wxWidgets-*"
+          $folder = Get-ChildItem -Path "C:\" -Filter $folderWildCard -Directory | Select-Object -First 1
+          msbuild C:\$folder\samples\minimal\minimal_vc17.sln
+      - name: Find built binary
+        run: |
+          $folderWildCard = "wxWidgets-*"
+          $folder = Get-ChildItem -Path "C:\" -Filter $folderWildCard -Directory | Select-Object -First 1
+          $binary = Get-ChildItem -Path "C:\$folder\samples\minimal\vc_mswud\*.exe" | Select-Object -First 1
+          echo $binary


### PR DESCRIPTION
Added Python 3.11 to all jobs for added compatibility checks.

Added validation to jobs to verify the script works across all versions of Windows and Python.

Added ability for CI job to run and build the sample code without any extra setup to be performed.